### PR TITLE
HTML generation and bulk output file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ Here the task "readmeToHtml" will create
 	-- build
 		---README.html
 ```
+Additionally there are `buildPdf` and `buildHtml` tasks that build all markdown files.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ task exampleTask3(type: MarkdownToHtmlTask){
 	outputFile = '/PATH/TO/CHANGELOG.html'
 }
 ```
-Default Task Example:
+
+## Default tasks
+Directory Layout Example:
 ```
 - example
 	-- build.gradle

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ task exampleTask2(type: MarkdownToPdfTask){
 	inputFile = '/PATH/TO/CHANGELOG.md'
 	outputFile = '/PATH/TO/CHANGELOG.pdf'
 }
+
+task exampleTask3(type: MarkdownToHtmlTask){
+	inputFile = '/PATH/TO/CHANGELOG.md'
+	outputFile = '/PATH/TO/CHANGELOG.html'
+}
 ```
 Default Task Example:
 ```
@@ -41,11 +46,19 @@ Default Task Example:
 	-- build.gradle
 	-- README.md
 ```
-Here you can use the task "readmeToPdf" which will create
+Here the task "readmeToPdf" will create
 ```
 - example
 	-- build.gradle
 	-- README.md
 	-- build
 		---README.pdf
+```
+Here the task "readmeToHtml" will create
+```
+- example
+	-- build.gradle
+	-- README.md
+	-- build
+		---README.html
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ spotless {
 	java { googleJavaFormat() }
 	groovy { greclipse() }
 	groovyGradle { greclipse() }
+
+	lineEndings = com.diffplug.spotless.LineEnding.UNIX
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ dependencies {
 	testCompile gradleTestKit()
 	testCompile 'junit:junit:4+'
 
-	pluginDependency 'com.vladsch.flexmark:flexmark:0.32.2'
-	pluginDependency 'com.vladsch.flexmark:flexmark-pdf-converter:0.32.2'
+	pluginDependency 'com.vladsch.flexmark:flexmark:0.34.52'
+	pluginDependency 'com.vladsch.flexmark:flexmark-pdf-converter:0.34.52'
 
 	// Adds pluginDependency to gradle plugin jar
 	configurations.compile.extendsFrom(configurations.pluginDependency)

--- a/src/main/groovy/de/fntsoftware/gradle/AbstractMarkdownTask.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/AbstractMarkdownTask.groovy
@@ -1,0 +1,57 @@
+package de.fntsoftware.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+
+class AbstractMarkdownTask extends DefaultTask {
+
+	/** Value which can be resolved using {@link org.gradle.api.Project#file(Object object)} */
+	private File inputFile
+
+	/** Value which can be resolved using {@link org.gradle.api.Project#file(Object object)} */
+	protected File outputFile
+
+	protected MutableDataSet options = new MutableDataSet()
+
+	@InputFile
+	File getInputFile() {
+		return this.inputFile
+	}
+
+	File setInputFile(Object file) {
+		this.inputFile = getProject().file(file)
+	}
+
+	@OutputFile
+	File getOutputFile() {
+		return this.outputFile
+	}
+
+	File setOutputFile(Object file) {
+		this.outputFile = getProject().file(file)
+	}
+
+	protected String buildHtml() {
+		MarkdownToPdf settings = this.getProject().getExtensions().getByType(MarkdownToPdf.class);
+		if(this.inputFile.exists()) {
+			def outputDir = new File(outputFile.parent)
+			outputDir.mkdirs()
+
+			def parser = Parser.builder(options).build()
+			def renderer = HtmlRenderer.builder(options).build()
+
+			def document = parser.parse(this.inputFile.getText())
+			def css = settings.getCssFileContent()
+			return "<html><head><style>${css}</style></head><body>${renderer.render(document)}</body></html>"
+		}
+		else {
+			throw new InvalidUserDataException("Inputfile does not exist.")
+		}
+	}
+}

--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToHtmlTask.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToHtmlTask.groovy
@@ -1,0 +1,11 @@
+package de.fntsoftware.gradle
+
+import org.gradle.api.tasks.TaskAction
+
+class MarkdownToHtmlTask extends AbstractMarkdownTask {
+	@TaskAction
+	void action() {
+		File file = new File(this.outputFile.path)
+		file << buildHtml()
+	}
+}

--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
@@ -14,13 +14,14 @@ class MarkdownToPdfPlugin implements Plugin<Project> {
 
 		project.fileTree([dir: '.', include: '*.md']).files.each { file ->
 			def fileNameWithoutExtension = file.name.take(file.name.lastIndexOf('.'))
+			def taskName = fileNameWithoutExtension.toLowerCase().replace(" ", "")
 
-			def pdfTask = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToPdf", MarkdownToPdfTask)
+			def pdfTask = project.tasks.create("${taskName}ToPdf", MarkdownToPdfTask)
 			pdfTask.inputFile = file
 			pdfTask.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.pdf'
 			buildPdfTask.dependsOn(pdfTask)
 
-			def htmlTask = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToHtml", MarkdownToHtmlTask)
+			def htmlTask = project.tasks.create("${taskName}ToHtml", MarkdownToHtmlTask)
 			htmlTask.inputFile = file
 			htmlTask.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.html'
 			buildHtmlTask.dependsOn(htmlTask)

--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
@@ -9,16 +9,21 @@ class MarkdownToPdfPlugin implements Plugin<Project> {
 		// disable logging
 		System.setProperty('xr.util-logging.loggingEnabled', 'false')
 
+		def buildPdfTask = project.tasks.create('buildPdf')
+		def buildHtmlTask = project.tasks.create('buildHtml')
+
 		project.fileTree([dir: '.', include: '*.md']).files.each { file ->
 			def fileNameWithoutExtension = file.name.take(file.name.lastIndexOf('.'))
 
 			def pdfTask = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToPdf", MarkdownToPdfTask)
 			pdfTask.inputFile = file
 			pdfTask.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.pdf'
+			buildPdfTask.dependsOn(pdfTask)
 
 			def htmlTask = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToHtml", MarkdownToHtmlTask)
 			htmlTask.inputFile = file
 			htmlTask.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.html'
+			buildHtmlTask.dependsOn(htmlTask)
 		}
 		project.extensions.add('markdownToPdf', new MarkdownToPdf())
 	}

--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
@@ -12,10 +12,13 @@ class MarkdownToPdfPlugin implements Plugin<Project> {
 		project.fileTree([dir: '.', include: '*.md']).files.each { file ->
 			def fileNameWithoutExtension = file.name.take(file.name.lastIndexOf('.'))
 
-			def task = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToPdf", MarkdownToPdfTask)
+			def pdfTask = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToPdf", MarkdownToPdfTask)
+			pdfTask.inputFile = file
+			pdfTask.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.pdf'
 
-			task.inputFile = file
-			task.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.pdf'
+			def htmlTask = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToHtml", MarkdownToHtmlTask)
+			htmlTask.inputFile = file
+			htmlTask.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.html'
 		}
 		project.extensions.add('markdownToPdf', new MarkdownToPdf())
 	}

--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
@@ -10,13 +10,12 @@ class MarkdownToPdfPlugin implements Plugin<Project> {
 		System.setProperty('xr.util-logging.loggingEnabled', 'false')
 
 		project.fileTree([dir: '.', include: '*.md']).files.each { file ->
-			def fileName = file.getName()
-			def fileNameWithoutExtension = fileName.take(fileName.lastIndexOf('.'))
+			def fileNameWithoutExtension = file.name.take(file.name.lastIndexOf('.'))
 
-			def task = project.getTasks().create("${fileNameWithoutExtension.toLowerCase()}ToPdf", MarkdownToPdfTask)
+			def task = project.tasks.create("${fileNameWithoutExtension.toLowerCase()}ToPdf", MarkdownToPdfTask)
 
 			task.inputFile = file
-			task.outputFile = project.getBuildDir().getPath() + '/' + fileNameWithoutExtension + '.pdf'
+			task.outputFile = project.buildDir.path + '/' + fileNameWithoutExtension + '.pdf'
 		}
 		project.extensions.add('markdownToPdf', new MarkdownToPdf())
 	}

--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
@@ -23,4 +23,3 @@ class MarkdownToPdfPlugin implements Plugin<Project> {
 		project.extensions.add('markdownToPdf', new MarkdownToPdf())
 	}
 }
-

--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfTask.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfTask.groovy
@@ -1,62 +1,12 @@
 package de.fntsoftware.gradle
 
-import org.gradle.api.DefaultTask
-import org.gradle.api.InvalidUserDataException
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
-import com.vladsch.flexmark.html.HtmlRenderer;
-import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.pdf.converter.PdfConverterExtension
-import com.vladsch.flexmark.util.options.MutableDataSet;
 
-class MarkdownToPdfTask extends DefaultTask {
-
-	/** Value which can be resolved using {@link org.gradle.api.Project#file(Object object)} */
-	private File inputFile
-
-	/** Value which can be resolved using {@link org.gradle.api.Project#file(Object object)} */
-	private File outputFile
-
-	@InputFile
-	File getInputFile() {
-		return this.inputFile
-	}
-
-	File setInputFile(Object file) {
-		this.inputFile = getProject().file(file)
-	}
-
-	@OutputFile
-	File getOutputFile() {
-		return this.outputFile
-	}
-
-	File setOutputFile(Object file) {
-		this.outputFile = getProject().file(file)
-	}
-
+class MarkdownToPdfTask extends AbstractMarkdownTask {
 	@TaskAction
 	void action() {
-		MarkdownToPdf settings = this.getProject().getExtensions().getByType(MarkdownToPdf.class);
-		if(this.inputFile.exists()) {
-			def outputDir = new File(outputFile.parent)
-			outputDir.mkdirs()
-
-			def options = new MutableDataSet()
-
-			def parser = Parser.builder(options).build()
-			def renderer = HtmlRenderer.builder(options).build()
-
-			def document = parser.parse(this.inputFile.getText())
-			def css = settings.getCssFileContent()
-			def html = "<html><head><style>${css}</style></head><body>${renderer.render(document)}</body></html>"
-
-			PdfConverterExtension.exportToPdf(this.outputFile.getPath(), html, "", options)
-		}
-		else {
-			throw new InvalidUserDataException("Inputfile does not exist.")
-		}
+		PdfConverterExtension.exportToPdf(this.outputFile.path, buildHtml(), "", options)
 	}
 }


### PR DESCRIPTION
Thanks for this code! I'd like to extend it a bit to cover two additional cases I have:
* `xxxToHtml` tasks which build an HTML file for each input markdown file.
* `buildHtml` and `buildPdf` tasks which build all possible html/pdf files accordingly.

There are also several other changes:
* the README is updated with the new features
* `flexmark` is updated
* Unix line endings are used explicitly in Spotless to avoid incompatibility with Windows
* some groovy features are used to shorten code