### PR TITLE
Strip all invalid characters from task names

### DIFF
--- a/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
+++ b/src/main/groovy/de/fntsoftware/gradle/MarkdownToPdfPlugin.groovy
@@ -4,6 +4,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class MarkdownToPdfPlugin implements Plugin<Project> {
+	private static final FORBIDDEN_CHARACTERS = [" ", "/", "\\", ":", "<", ">", "\"", "?", "*", "|"]
+
 	@Override
 	void apply(Project project) {
 		// disable logging
@@ -14,7 +16,9 @@ class MarkdownToPdfPlugin implements Plugin<Project> {
 
 		project.fileTree([dir: '.', include: '*.md']).files.each { file ->
 			def fileNameWithoutExtension = file.name.take(file.name.lastIndexOf('.'))
-			def taskName = fileNameWithoutExtension.toLowerCase().replace(" ", "")
+			def taskName = fileNameWithoutExtension.toLowerCase()
+
+			taskName = FORBIDDEN_CHARACTERS.inject(taskName, { name, character -> name.replace(character, "") })
 
 			def pdfTask = project.tasks.create("${taskName}ToPdf", MarkdownToPdfTask)
 			pdfTask.inputFile = file


### PR DESCRIPTION
I found one little issue. Having one of a couple of characters make gradle complain with:

```
The task name 'some fileToPdf' contains at least one of the following characters: [ , /, \, :, <, >, ", ?, *, |]. This has been deprecated and is scheduled to be removed in Gradle 5.0.
```

... this fixes it.